### PR TITLE
`Curve` struct with points on elliptic 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+const SEVEN: [u8; 32] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07
+];
 
 /// curve's field prime
 const P: [u8; 32] = [
@@ -86,10 +92,40 @@ fn get_random_values(buffer: &mut [u8]) {
     }
 }
 
+struct Curve {
+    p: [u8; 32],
+    n: [u8; 32],
+    a: [u8; 32],
+    b: [u8; 32],
+    gx: [u8; 32],
+    gy: [u8; 32]
+}
+
+impl Curve {
+    pub fn new() -> Self {
+        Curve {
+            p: P.clone(),
+            n: N.clone(),
+            a: B256.clone(),
+            b: SEVEN.clone(),
+            gx: GX.clone(),
+            gy: GY.clone()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    
     #[test]
-    fn it_works() {}
+    fn create_curve_struct() {
+        let curve = Curve::new();
+        assert!(curve.p == P, "Curve p not valid");
+        assert!(curve.n == N, "Curve n not valid");
+        assert!(curve.a == B256, "Curve a not valid");
+        assert!(curve.b == SEVEN, "Curve b not valid");
+        assert!(curve.gx == GX, "Curve gx not valid");
+        assert!(curve.gy == GY, "Curve gy not valid");
+    }
 }


### PR DESCRIPTION
The secp256k1 curve is widely used in cryptographic systems, especially Bitcoin. It has the following key parameters:

1. **Prime Field (p)**: 
   \[
   p = 2^{256} - 2^{32} - 977
   \]

2. **Curve Equation**:
   \[
   y^2 = x^3 + 7
   \]
   with \(a = 0\) and \(b = 7\).

3. **Order (n)**:
   \[
   n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
   \]

4. **Generator Point (G)**:
   - \( G_x = 79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798 \)
   - \( G_y = 483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8 \)

Using this, we can define the curve struct in Rust. Here’s a Rust implementation with these secp256k1 parameters:

```rust
pub struct Curve {
    p: [u8; 32],
    n: [u8; 32],
    a: [u8; 32],
    b: [u8; 32],
    gx: [u8; 32],
    gy: [u8; 32],
}

impl Curve {
    pub fn secp256k1() -> Self {
        Curve {
            p: hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F"),
            n: hex_literal::hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"),
            a: [0; 32],
            b: {
                let mut b_arr = [0; 32];
                b_arr[31] = 7; // Set last byte to 7
                b_arr
            },
            gx: hex_literal::hex!("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"),
            gy: hex_literal::hex!("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8"),
        }
    }
}
```

This `Curve` struct is initialized specifically for the secp256k1 parameters using the `secp256k1` function, which you can call to create an instance with the appropriate field values.


Closes #6 